### PR TITLE
Bugfix: Fixing typo in variable used for permissions in auto-release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -13,7 +13,7 @@ jobs:
   if_merged:
     runs-on: ubuntu-latest
     permissions:
-      content: write
+      contents: write
       actions: read
     if: ${{ (github.event.pull_request.merged) && (github.actor != 'dependabot[bot]') }}
     steps:


### PR DESCRIPTION
### Bugfix
- Fixing typo in the variable used for permissions in auto-release workflow on auto-release

Will in addition resolve #19 